### PR TITLE
Add 'end' event handling, fix command HELO -> EHLO

### DIFF
--- a/src/smtp/smtp.ts
+++ b/src/smtp/smtp.ts
@@ -76,7 +76,7 @@ export const checkSMTP = async (sender: string, recipient: string, exchange: str
     })
     
     socket.on('end', () => {
-      r(createOutput('smtp', 'SMTP communication unexpectedly closed.'))
+      r(createOutput('smtp', 'Mail server closed connection without sending any data.'))
     });
   })
 }

--- a/src/smtp/smtp.ts
+++ b/src/smtp/smtp.ts
@@ -42,7 +42,7 @@ export const checkSMTP = async (sender: string, recipient: string, exchange: str
       r(createOutput())
     })
 
-    const commands = [`helo ${exchange}\r\n`, `mail from: <${sender}>\r\n`, `rcpt to: <${recipient}>\r\n`]
+    const commands = [`EHLO ${exchange}\r\n`, `MAIL FROM: <${sender}>\r\n`, `RCPT TO: <${recipient}>\r\n`]
     let i = 0
     socket.on('next', () => {
       if (i < 3) {
@@ -74,5 +74,9 @@ export const checkSMTP = async (sender: string, recipient: string, exchange: str
         }
       })
     })
+    
+    socket.on('end', () => {
+      r(createOutput('smtp', 'SMTP communication unexpectedly closed.'))
+    });
   })
 }


### PR DESCRIPTION
1. Add 'end' event handling. 
example@uk.fujitsu.com hangs connection and node.js event loop can't resolve anything, so it closes process.

2. Fix command HELO -> EHLO; 
Correct command is `EHLO`. Proof: https://docs.microsoft.com/en-us/exchange/mail-flow/test-smtp-with-telnet?view=exchserver-2019.