### PR TITLE
Add more specific type for output reason using Level

### DIFF
--- a/src/output/output.ts
+++ b/src/output/output.ts
@@ -8,7 +8,12 @@ export type SubOutputFormat = {
 }
 
 type Level = ElementType<typeof OrderedLevels>
-export type OutputFormat = SubOutputFormat & {
+
+export interface GeneralOutputFormat extends SubOutputFormat {
+  reason?: Level
+}
+
+export type OutputFormat = GeneralOutputFormat & {
   validators: {
     [K in Level]?: SubOutputFormat
   }


### PR DESCRIPTION
The existing OutputFormat defines that the `reason` property can be _any_ string because it uses the `SubOutputFormat` interface which defines this property as `reason?: string`.

This can be rather confusing as to what the `(await validate("email@example.com")).reason` can be. The example in the README shows that it can be "smtp" and it is left to the assumption of the developer to figure out that it could be the same as the names of the keys in the `validators` object.

This PR addresses this issue by creating a new interface that defines the actual values that the `OutputFormat.reason` can have (defined in the `Level` type).