### PR TITLE
Fix SMTP socket lifecycle, hasCode matching, and regex permissiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "lint": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix"
   },
   "dependencies": {
-    "@types/disposable-email-domains": "^1.0.6",
     "disposable-email-domains": "^1.0.62",
     "mailcheck": "^1.1.1"
   },
   "devDependencies": {
+    "@types/disposable-email-domains": "^1.0.6",
     "@types/mailcheck": "^1.1.37",
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",

--- a/src/regex/regex.ts
+++ b/src/regex/regex.ts
@@ -21,5 +21,8 @@ export const isEmail = (email: string): string | undefined => {
   if (domain.indexOf('.') === -1) {
     return 'Must contain a "." after the "@".'
   }
+  if (/[\s\x00-\x1f\x7f]/.test(email)) {
+    return 'Email contains invalid characters.'
+  }
   return undefined
 }

--- a/src/smtp/errorCodes.ts
+++ b/src/smtp/errorCodes.ts
@@ -24,5 +24,5 @@ export const ErrorCodes = {
 
 export const hasCode = (message: string, code: keyof typeof ErrorCodes): boolean => {
   const codeStr = String(code)
-  return message.indexOf(codeStr) === 0 || message.indexOf(codeStr + '\n') > -1
+  return new RegExp(`^${codeStr}[\\s-]`).test(message) || new RegExp(`\\n${codeStr}[\\s-]`).test(message)
 }

--- a/src/smtp/smtp.ts
+++ b/src/smtp/smtp.ts
@@ -30,28 +30,21 @@ export const checkSMTP = async (sender: string, recipient: string, exchange: str
     socket.on('close', (hadError: boolean) => {
       if (!receivedData && !hadError) {
         socket.emit('fail', 'Mail server closed connection without sending any data.')
-      }
-      if (!closed) {
+      } else if (!closed) {
         socket.emit('fail', 'Mail server closed connection unexpectedly.')
       }
     })
     socket.once('fail', (msg: unknown) => {
       closed = true
       r(createOutput('smtp', String(msg)))
-      if (socket.writable && !socket.destroyed) {
-        socket.write(`quit\r\n`)
-        socket.end()
-        socket.destroy()
-      }
+      socket.removeAllListeners()
+      socket.destroy()
     })
 
     socket.on('success', () => {
       closed = true
-      if (socket.writable && !socket.destroyed) {
-        socket.write(`quit\r\n`)
-        socket.end()
-        socket.destroy()
-      }
+      socket.removeAllListeners()
+      socket.destroy()
       r(createOutput())
     })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -47,6 +47,14 @@ describe('security: regex edge cases', () => {
   it('rejects email without @', () => {
     expect(isEmail('usergmail.com')).toBe('Email does not contain "@".')
   })
+
+  it('rejects email with spaces', () => {
+    expect(isEmail('dav id@gmail.com')).toBe('Email contains invalid characters.')
+  })
+
+  it('rejects email with control characters', () => {
+    expect(isEmail('user\x00@gmail.com')).toBe('Email contains invalid characters.')
+  })
 })
 
 describe('validation tests', () => {


### PR DESCRIPTION
## Why

Several correctness and security issues found during code review:
- SMTP socket `close` handler emitted `fail` twice due to missing `else`
- `hasCode` matched partial SMTP codes (e.g. `2501` matched as `250`)
- Socket called `write`/`end`/`destroy` in sequence — `destroy` before flush
- No listener cleanup on sockets after resolution
- Regex validator accepted emails with spaces and control characters
- `@types/disposable-email-domains` was in runtime dependencies

## What changed

| Before | After |
|--------|-------|
| `close` handler emits `fail` twice when no data received | `else if` prevents double emit |
| `hasCode("2501...", 250)` returns `true` | Regex enforces `\s` or `-` delimiter after code |
| Socket calls `write("quit")`, `end()`, `destroy()` — quit never sent | Just `destroy()` — clean teardown, no pretense of graceful QUIT |
| No `removeAllListeners()` on socket | Listeners removed on both `fail` and `success` paths |
| `isEmail("dav id@gmail.com")` returns `undefined` (valid) | Returns `"Email contains invalid characters."` |
| `@types/disposable-email-domains` in `dependencies` | Moved to `devDependencies` |